### PR TITLE
Add a new -F option for foreground mode

### DIFF
--- a/htpdate.8
+++ b/htpdate.8
@@ -3,7 +3,7 @@
 htpdate \- Time synchronization (daemon)
 .SH "SYNOPSIS"
 .B htpdate
-[\-046abdhlqstxD] [\-i pid file] [\-m minpoll] [\-M maxpoll] [\-p precision] [\-P <proxyserver>[:port]] [\-u user[:group]] <host[:port]> ...
+[\-046abdhlqstxDF] [\-i pid file] [\-m minpoll] [\-M maxpoll] [\-p precision] [\-P <proxyserver>[:port]] [\-u user[:group]] <host[:port]> ...
 .SH "DESCRIPTION"
 The HTTP Time Protocol (HTP) is used to synchronize a computer's
 time with web servers as reference time source. Htp will synchronize
@@ -67,6 +67,10 @@ Let htpdate compensate for the systematisch clock drift.
 .TP
 .I \-D
 Run as daemon (requires root privileges).
+.TP
+.I \-F
+Run in the foreground (requires root privileges). This is the same as \-D but
+will not fork or write a PID file.
 .TP 
 .I \-P
 Proxy server hostname or ip-address.
@@ -101,6 +105,10 @@ HTTP/1.0 request in IPv6 literal format (RFC 2732):
 Run htpdate as daemon:
 .br
 \&       htpdate \-D www.example.com
+.P
+Run htpdate in the foreground with all output going to the terminal:
+.br
+\&       htpdate \-F www.example.com
 .P
 Daemon mode for the security minded:
 .br

--- a/scripts/htpdate.service
+++ b/scripts/htpdate.service
@@ -3,11 +3,10 @@ Description=htpdate daemon
 After=network.target
 
 [Service]
-Type=forking
-PIDFile=/var/run/htpdate
+Type=exec
 Environment=HTPDATE_ARGS="-a -s -t http://www.google.com https://www.google.com"
 EnvironmentFile=-/etc/default/htpdate
-ExecStart=/usr/bin/htpdate -D -i /var/run/htpdate $HTPDATE_ARGS
+ExecStart=/usr/bin/htpdate -F $HTPDATE_ARGS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Foreground mode works like daemon mode, except that it doesn't force logging to syslog, doesn't fork, and doesn't create a PID file. It is meant for use with service managers that handle log redirection and process tracking automatically, such as systemd.

The double forking used in daemon mode does not follow the _forking_ completion protocol in systemd, which expects the PID file to be written and the main process to be running after the first fork, not the second. This can cause the service to fail when systemd can't find the PID file after the first fork. Not forking at all and using the _exec_ completion protocol instead is simpler and less error-prone, as it lets systemd track the main process directly.