### PR TITLE
htpdate: add error message when get fails

### DIFF
--- a/htpdate.c
+++ b/htpdate.c
@@ -364,6 +364,9 @@ static long getHTTPdate( char *host, char *port, char *proxy, char *proxyport, c
 #endif
 		rc = getHTTP(server_s, buffer);
 
+	if ( !rc )
+		printlog( 1, "error getting data from %s:%s", host, port );
+
 	if ( rc ) {
 		/* Assuming that network delay (server->htpdate) is neglectable,
 		   the received web server time "should" match the local time.


### PR DESCRIPTION
When http(s) GET fails for some reason, the time is defaulted to the
epoch, the offset became quite large and later discarded by the sanity
check.
Even if the behavior is right, is not always clear from the output why
a server should return such a wrong offset.

Signed-off-by: Angelo Compagnucci <angelo.compagnucci@gmail.com>