### PR TITLE
htpdate: corret url when port number is used

### DIFF
--- a/htpdate.c
+++ b/htpdate.c
@@ -139,13 +139,17 @@ static void splithostport( char **host, char **port )
 	lc = strchr( *host, ':' );
 	rc = strrchr( *host, ':' );
 
+	/* A (litteral) address with "https://" prefix */
 	if (strstr(*host, "https://") == *host) {
+		rc[0] = '\0';
 		*host = *host + strlen("https://");
 		*port = "443\0";
 		return;
 	}
 
+	/* A (litteral) address with "http://" prefix */
 	if (strstr(*host, "http://") == *host) {
+		rc[0] = '\0';
 		*host = *host + strlen("http://");
 		*port = "80\0";
 		return;


### PR DESCRIPTION
When both "http://" or "https://" prefix and port number are used,
the port number was not correctly removed from the url making the url
invalid.

Fixes: #17
Signed-off-by: Angelo Compagnucci <angelo.compagnucci@gmail.com>