### PR TITLE
Only drop privileges when configured

### DIFF
--- a/htpdate.c
+++ b/htpdate.c
@@ -910,7 +910,7 @@ int main( int argc, char *argv[] )
 					printlog( 1, "Time change failed" );
 
 				/* Drop root privileges again */
-				swuid( sw_uid );
+				if ( sw_uid ) swuid( sw_uid );
 
 				if ( daemonize || foreground ) {
 					if ( starttime ) {
@@ -927,7 +927,7 @@ int main( int argc, char *argv[] )
 								printlog( 1, "Frequency change failed" );
 
 							/* Drop root privileges again */
-							swuid( sw_uid );
+							if ( sw_uid ) swuid( sw_uid );
 						}
 					} else {
 						starttime = time(NULL);


### PR DESCRIPTION
You inherited some bugs from 1.2.2. This one is too ugly not to be fixed.

Every non-root user will get this error; **seteuid() 0**... as it tries to drop privileges when not possible

$ ./htpdate www.gazzetta.it
Offset 1.000 seconds
seteuid() 0
